### PR TITLE
Add signal handling for graceful termination of Electron app on Unix based systems

### DIFF
--- a/run/run-proctor.sh
+++ b/run/run-proctor.sh
@@ -3,6 +3,24 @@
 # URL of the raw file
 URL="https://raw.githubusercontent.com/dsasidhar/electron-proctor/refs/heads/main/dist/proctoring-tool.js"
 OUTPUT_FILE="proctoring-tool.js"
+PID_FILE="electron-proctor.pid"
+
+# Function to clean up and terminate the Electron app
+cleanup() {
+    if [ -f "$PID_FILE" ]; then
+        ELECTRON_PID=$(cat "$PID_FILE")
+        if kill -0 "$ELECTRON_PID" 2>/dev/null; then
+            echo "Terminating Electron app with PID $ELECTRON_PID..."
+            kill "$ELECTRON_PID"
+        fi
+        rm -f "$PID_FILE"
+    fi
+    echo "Cleanup complete. Exiting."
+    exit 0
+}
+
+# Trap signals and call cleanup
+trap cleanup SIGINT SIGTERM
 
 # Download the file
 echo "Downloading $OUTPUT_FILE..."
@@ -17,7 +35,16 @@ if [ ! -f "$OUTPUT_FILE" ]; then
     exit 1
 fi
 
-echo "Download complete. Running with electron..."
+echo "Download complete. Running with Electron..."
 
-# Run with npx electron
-npx electron "$OUTPUT_FILE"
+# Run with npx electron and save the PID
+npx electron "$OUTPUT_FILE" &
+ELECTRON_PID=$!
+echo $ELECTRON_PID > "$PID_FILE"
+echo "Electron app started with PID $ELECTRON_PID. Press Ctrl+C to terminate gracefully."
+
+# Wait for the Electron process to finish
+wait $ELECTRON_PID
+
+# Cleanup the PID file on exit
+cleanup


### PR DESCRIPTION
This PR enhances the `run-proctor.sh` script by adding signal handling to ensure the Electron app terminates gracefully when interrupted (e.g., via `Ctrl+C` or `kill`). Key updates include:

Capturing Unix signals (`SIGINT`, `SIGTERM`) to perform cleanup before exiting.
Automatically terminating the Electron process and removing the PID file upon interruption.
These changes improve process management, prevent orphaned processes, and make it easier for users to stop the application cleanly.